### PR TITLE
fix dpdk runtime bug based on spdk/dpdk

### DIFF
--- a/drivers/net/ixgbe/ixgbe_rxtx.c
+++ b/drivers/net/ixgbe/ixgbe_rxtx.c
@@ -1589,6 +1589,7 @@ ixgbe_rx_alloc_bufs(struct ixgbe_rx_queue *rxq, bool reset_mbuf)
 		}
 
 		rte_mbuf_refcnt_set(mb, 1);
+                mb->next = NULL;
 		mb->data_off = RTE_PKTMBUF_HEADROOM;
 
 		/* populate the descriptors */

--- a/lib/librte_mbuf/rte_mbuf.c
+++ b/lib/librte_mbuf/rte_mbuf.c
@@ -102,7 +102,6 @@ rte_pktmbuf_pool_init(struct rte_mempool *mp, void *opaque_arg)
 	}
 
 	RTE_ASSERT(mp->elt_size >= sizeof(struct rte_mbuf) +
-		user_mbp_priv->mbuf_data_room_size +
 		user_mbp_priv->mbuf_priv_size);
 
 	mbp_priv = rte_mempool_get_priv(mp);
@@ -233,6 +232,9 @@ rte_mbuf_sanity_check(const struct rte_mbuf *m, int is_header)
 	}
 	if (nb_segs != 0)
 		rte_panic("bad nb_segs\n");
+        if (m_seg != NULL)
+                rte_panic("bad m_seg\n");
+
 }
 
 /* dump a mbuf on console */


### PR DESCRIPTION
ceph async messenger has some run time error with this dpdk library, 1) need init mb->next= null when allocate a buffer other wise rte_mbuf_sanity_check will report error.  2) when check the size, can't calculate mbuf_data_room_size because async messenger dpdk will allocate this part later not at create mempool.   

Signed-off-by: chunmei chunmei.liu@intel.com