### PR TITLE
eal_common_options.c:verify_perms(): remove per-thread object.

### DIFF
--- a/lib/eal/common/eal_common_options.c
+++ b/lib/eal/common/eal_common_options.c
@@ -431,7 +431,7 @@ verify_perms(const char *dirpath)
 
 	/* if not root, check down one level first */
 	if (strcmp(dirpath, "/") != 0) {
-		static __thread char last_dir_checked[PATH_MAX];
+		static char last_dir_checked[PATH_MAX] = {};
 		char copy[PATH_MAX];
 		const char *dir;
 


### PR DESCRIPTION
verify_perms() defines a 4KB TLS array last_dir_checked to avoid re-checking permissions on the same directory again.

This array is added to the TLS of every thread in the process. This wastes memory (a bit, arguably) and makes it impossible to use fast 'initial-exec' tls model in shared libraries linked with spdk/dpdk.

Fix: simply drop '__thread' qualifier, the code is only ever executed
during single-threaded initialisation: rte_eal_init() -> eal_plugins_init() -> eal_dlopen() -> verify_perms().